### PR TITLE
Update Template storage structure

### DIFF
--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -13,7 +13,7 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends AddressBookStorage, UserPrefsStorage {
+public interface Storage extends AddressBookStorage, UserPrefsStorage, TemplateStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;

--- a/src/main/java/seedu/address/storage/TemplateStorage.java
+++ b/src/main/java/seedu/address/storage/TemplateStorage.java
@@ -1,54 +1,26 @@
 package seedu.address.storage;
 
-import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Scanner;
 
 import seedu.address.model.template.Template;
 
 /**
  * Represents a storage for {@link seedu.address.model.template.Template}.
  */
-public class TemplateStorage {
+public interface TemplateStorage {
 
-    private String filePath;
+    Path getTemplateFilePath();
 
-    public TemplateStorage() {
-    }
-
-    public TemplateStorage(String filePath) {
-        this.filePath = filePath;
-    }
-
-    //@Override
-    public String getTemplateFilePath() {
-        return filePath;
-    }
-
-    //@Override
-    public Optional<Template> readTemplateFromFile() throws FileNotFoundException {
-        return readTemplateFromFile(filePath);
-    }
+    Optional<Template> loadTemplate() throws IOException;
 
     /**
-     * Similar to {@link #readTemplateFromFile()}
+     * Similar to {@link #loadTemplate()}
      *
-     * @param templateFilePath location of the data. Cannot be null.
-     * @throws FileNotFoundException if the file is not found.
+     * @param filePath location of the data. Cannot be null.
+     * @throws IOException if the file is not found.
      */
-    public Optional<Template> readTemplateFromFile(String templateFilePath)
-        throws FileNotFoundException {
-        File file = new File(templateFilePath);
-        Scanner s = new Scanner(file);
-        Template t = new Template();
-
-        while (s.hasNextLine()) {
-            String curr = s.nextLine();
-            t.addSection(curr);
-        }
-        return Optional.of(t);
-    }
+    Optional<Template> loadTemplate(Path filePath)
+        throws IOException;
 }
-
-

--- a/src/main/java/seedu/address/storage/TxtTemplateStorage.java
+++ b/src/main/java/seedu/address/storage/TxtTemplateStorage.java
@@ -1,0 +1,78 @@
+package seedu.address.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.template.Template;
+
+/**
+ * Represents a storage for {@link seedu.address.model.template.Template}.
+ */
+public class TxtTemplateStorage implements TemplateStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(TxtTemplateStorage.class);
+
+    private Path filePath;
+
+    public TxtTemplateStorage() {
+    }
+
+    public TxtTemplateStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    //@Override
+    public Path getTemplateFilePath() {
+        return filePath;
+    }
+
+    //@Override
+    public Optional<Template> loadTemplate() throws IOException {
+        return loadTemplate(filePath);
+    }
+
+    /**
+     * Similar to {@link #loadTemplate()}
+     *
+     * @param filePath location of the data. Cannot be null.
+     * @throws IOException if the file is not found.
+     */
+    public Optional<Template> loadTemplate(Path filePath)
+        throws IOException {
+        /*TODO:
+        should it return a Optional<Template> or just Template?
+        XmlAddrBkStorage returns Optional to Main, and Main creates a default
+        AddrBk if Optional is empty.
+
+        TxtTemplateStorage returns <VALUE> to StorageManager's
+        HandleTemplateLoadRequested() which was triggered by a TemplateLoadRequestedEvent
+        HandleTemp... then raises a TemplateLoadedEvent or TemplateLoadingExceptionEvent
+        */
+        requireNonNull(filePath);
+
+        if (!Files.exists(filePath)) {
+            logger.info("Template file " + filePath + " not found");
+            return Optional.empty();
+        }
+
+        File file = filePath.toFile();
+        Scanner s = new Scanner(file);
+        Template template = new Template();
+
+        while (s.hasNextLine()) {
+            String curr = s.nextLine();
+            template.addSection(curr);  //TODO: should this be in template?
+        }
+        return Optional.of(template);
+    }
+}
+
+


### PR DESCRIPTION
TemplateStorage now follows a similar structure to that of AddressBookStorage and UserPrefsStorage, i.e.
- `TemplateStorage` is now an interface implemented by `TxtTemplateStorage`
- `StorageManager` still implements `Storage`, which now also extends `TemplateStorage`
- `StorageManager` also contains an instance of `TxtTemplateStorage`, and forwards function calls to it

The listener in `StorageManager` (`handleTemplateLoadRequestedEvent(..)`) will now raise either of the new `TemplateLoadedEvent` / `TemplateLoadingExceptionEvent` when triggered by `TemplateLoadRequestedEvent`.