### PR TITLE
Add de-serialisation for entry and entrybook (from XML to in-memory java object)

### DIFF
--- a/src/main/java/seedu/address/model/template/Template.java
+++ b/src/main/java/seedu/address/model/template/Template.java
@@ -119,4 +119,22 @@ public class Template {
     public String toString() {
         return stringRepresentation;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof Template)) {
+            return false;
+        }
+
+        // state check
+        Template other = (Template) obj;
+        return sections.equals(other.sections)
+                && stringRepresentation.equals(other.stringRepresentation);
+    }
 }

--- a/src/main/java/seedu/address/model/template/TemplateSection.java
+++ b/src/main/java/seedu/address/model/template/TemplateSection.java
@@ -30,4 +30,23 @@ public class TemplateSection {
     public Predicate<ResumeEntry> getTagPredicate() {
         return tagPredicate;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof TemplateSection)) {
+            return false;
+        }
+
+        // state check
+        TemplateSection other = (TemplateSection) obj;
+        return title.equals(other.title)
+                && catePredicate.equals(other.catePredicate)
+                && tagPredicate.equals(other.tagPredicate);
+    }
 }

--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryDescription.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryDescription.java
@@ -1,0 +1,58 @@
+package seedu.address.storage.entry;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.EntryDescription;
+
+/** A JAXB friendly version of EntryDescription */
+public class XmlAdaptedEntryDescription {
+
+    public static final String MESSAGE_MISSING_BULLETS = "Description element, if provided, cannot be empty.";
+
+    @XmlElement(name = "bullet")
+    private List<String> bullets;
+
+    /**
+     * Default constructor needed by JAXB
+     */
+    public XmlAdaptedEntryDescription() {}
+
+    /**
+     * Converts this jaxb-friendly adapted entry description object into the model's EntryDescription object.
+     * // TODO: Add data validation
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entry description.
+     */
+    public EntryDescription toModelType() throws IllegalValueException {
+        EntryDescription desc = new EntryDescription();
+
+        if (bullets == null) {
+            throw new IllegalValueException(MESSAGE_MISSING_BULLETS);
+        }
+
+        for (String bullet : bullets) {
+            // TODO: Validate bullet
+            desc.addBullet(bullet);
+        }
+
+        return desc;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedEntryInfo)) {
+            return false;
+        }
+
+        XmlAdaptedEntryDescription entryDescription = (XmlAdaptedEntryDescription) other;
+        return bullets.equals(entryDescription.bullets);
+
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryInfo.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryInfo.java
@@ -1,0 +1,70 @@
+package seedu.address.storage.entry;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.EntryInfo;
+
+/** A JAXB friendly version of EntryInfo */
+public class XmlAdaptedEntryInfo {
+
+    private static final String MESSAGE_MISSING_ENTRY_INFO = "An entry is missing the %s field";
+
+    @XmlAttribute
+    private String title;
+    @XmlAttribute
+    private String subheader;
+    @XmlAttribute
+    private String duration;
+
+    public XmlAdaptedEntryInfo() {}
+
+    /**
+     * Converts this jaxb-friendly adapted entry info object into the model's EntryInfo object
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entry info
+     */
+    public EntryInfo toModelType() throws IllegalValueException {
+
+        /** If entryInfo has been specified in XML, all 3 fields must be provided */
+        if (title == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "title"));
+        }
+
+        if (subheader == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "subheader"));
+        }
+
+        if (duration == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "duration"));
+        }
+
+        List<String> toBeValidated = Arrays.asList(title, subheader, duration);
+
+        if (!EntryInfo.isValidEntryInfo(toBeValidated)) {
+            throw new IllegalValueException(EntryInfo.MESSAGE_ENTRYINFO_CONSTRAINTS);
+        }
+
+        return new EntryInfo(title, subheader, duration);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedEntryInfo)) {
+            return false;
+        }
+
+        XmlAdaptedEntryInfo otherAdaptedEntryInfo = (XmlAdaptedEntryInfo) other;
+        return Objects.equals(title, otherAdaptedEntryInfo.title)
+                 && Objects.equals(subheader, otherAdaptedEntryInfo.subheader)
+                 && Objects.equals(duration, otherAdaptedEntryInfo.duration);
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedResumeEntry.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedResumeEntry.java
@@ -1,0 +1,108 @@
+package seedu.address.storage.entry;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.category.Category;
+import seedu.address.model.entry.EntryDescription;
+import seedu.address.model.entry.EntryInfo;
+import seedu.address.model.entry.ResumeEntry;
+import seedu.address.model.tag.Tag;
+
+/**
+ * JAXB-friendly version of the ResumeEntry.
+ */
+public class XmlAdaptedResumeEntry {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Entry's %s field is missing!";
+
+    @XmlAttribute
+    private String category;
+    @XmlElement
+    private XmlAdaptedEntryInfo entryInfo;
+    @XmlElement
+    private XmlAdaptedEntryDescription entryDesc;
+    @XmlElement
+    private List<String> tags = new LinkedList<String>();
+
+    /**
+     * Constructs an XmlAdaptedPerson.
+     * This is the no-arg constructor that is required by JAXB.
+     */
+    public XmlAdaptedResumeEntry() {}
+
+
+    /**
+     * Converts this jaxb-friendly adapted resume entry object into the model's ResumeEntry object.
+     * // TODO: Add data validation
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted resume entry.
+     */
+    public ResumeEntry toModelType() throws IllegalValueException {
+
+        if (category == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                                                                  Category.class.getSimpleName()));
+        }
+
+        if (!Category.isValidCategoryName(category)) {
+            throw new IllegalValueException(Category.MESSAGE_CATE_CONSTRAINTS);
+        }
+
+        Category modelCategory = new Category(category);
+
+        /* tags are optional */
+        HashSet<Tag> modelTags = new HashSet<Tag>();
+
+        for (String t : tags) {
+            if (!Tag.isValidTagName(t)) {
+                throw new IllegalValueException(Tag.MESSAGE_TAG_CONSTRAINTS);
+            }
+
+            modelTags.add(new Tag(t));
+        }
+
+        /* entry info is optional */
+        EntryInfo modelEntryInfo;
+
+        if (entryInfo == null) {
+            modelEntryInfo = new EntryInfo();
+        } else {
+            modelEntryInfo = entryInfo.toModelType();
+        }
+
+        /* entry description is optional*/
+        if (entryDesc == null) {
+            return new ResumeEntry(modelCategory, modelEntryInfo, modelTags);
+        } else {
+
+            EntryDescription modelDescription = entryDesc.toModelType();
+            return new ResumeEntry(modelCategory, modelEntryInfo, modelTags, modelDescription);
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedResumeEntry)) {
+            return false;
+        }
+
+        XmlAdaptedResumeEntry otherResumeEntry = (XmlAdaptedResumeEntry) other;
+
+        return Objects.equals(category, otherResumeEntry.category)
+                && Objects.equals(entryInfo, otherResumeEntry.entryInfo)
+                && Objects.equals(entryDesc, otherResumeEntry.entryDesc)
+                && Objects.equals(tags, otherResumeEntry.tags);
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlSerializableEntryBook.java
+++ b/src/main/java/seedu/address/storage/entry/XmlSerializableEntryBook.java
@@ -1,0 +1,62 @@
+package seedu.address.storage.entry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.EntryBook;
+import seedu.address.model.entry.ResumeEntry;
+
+/**
+ * An Immutable EntryBook that is serializable to XML format
+ */
+@XmlRootElement(name = "entrybook")
+public class XmlSerializableEntryBook {
+
+    public static final String MESSAGE_DUPLICATE_ENTRY = "Entry list contains duplicate entries.";
+
+    @XmlElement(name = "entry")
+    private List<XmlAdaptedResumeEntry> resumeEntries;
+
+    /**
+     * Creates an empty XmlSerializableEntryBook.
+     * This empty constructor is required for marshalling.
+     */
+    public XmlSerializableEntryBook() {
+        resumeEntries = new ArrayList<>();
+    }
+
+
+    /**
+     * Converts this entrybook into the model's {@code EntryBook} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated or duplicates in the
+     * {@code XmlAdaptedResumeEntryBook}.
+     */
+    public EntryBook toModelType() throws IllegalValueException {
+        EntryBook entryBook = new EntryBook();
+        for (XmlAdaptedResumeEntry e : resumeEntries) {
+            ResumeEntry entry = e.toModelType();
+            if (entryBook.hasEntry(entry)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ENTRY);
+            }
+            entryBook.addEnty(entry);
+        }
+        return entryBook;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlSerializableEntryBook)) {
+            return false;
+        }
+        return resumeEntries.equals(((XmlSerializableEntryBook) other).resumeEntries);
+    }
+}

--- a/src/test/data/XmlSerializableEntryBookTest/invalidEntryTitle.xml
+++ b/src/test/data/XmlSerializableEntryBookTest/invalidEntryTitle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- The entry here contains an invalid title, as defined by the EntryInfo class -->
+<entrybook>
+<entry category="work">
+    <entryInfo title="" subheader="software engineering intern" duration="2010 - 2013"/>
+    <tags>java</tags>
+</entry>
+</entrybook>

--- a/src/test/data/XmlSerializableEntryBookTest/missingBullets.xml
+++ b/src/test/data/XmlSerializableEntryBookTest/missingBullets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<entrybook>
+<entry category="work">
+    <entryInfo title="Facebook" subheader="software engineering intern" duration="2010 - 2013"/>
+    <entryDesc>
+      <!-- There should be at least 1 valid bullet here! -->
+    </entryDesc>
+    <tags>java</tags>
+</entry>
+</entrybook>

--- a/src/test/data/XmlSerializableEntryBookTest/missingCategory.xml
+++ b/src/test/data/XmlSerializableEntryBookTest/missingCategory.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<entrybook>
+<entry category="work">
+    <entryInfo title="Facebook" subheader="software engineering intern" duration="2010 - 2013"/>
+    <tags>java</tags>
+</entry>
+<entry>
+    <!-- This entry has a missing category -->
+    <entryInfo title="National University of Singapore" subheader="Bachelor of computing" duration="2010 - 2013"/>
+    <tags>Machine Learning</tags>
+</entry>
+</entrybook>

--- a/src/test/data/XmlSerializableEntryBookTest/typicalEntryBook.xml
+++ b/src/test/data/XmlSerializableEntryBookTest/typicalEntryBook.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Entrybook save file which contains the same ResumeEntry values as in TypicalEntrys#getTypicalEntryBook() -->
+<entrybook>
+<entry category="work">
+    <entryInfo title="Facebook" subheader="software engineering intern" duration="2010 - 2013"/>
+    <tags>java</tags>
+</entry>
+<entry category="education">
+    <entryInfo title="National University of Singapore" subheader="Bachelor of computing" duration="2010 - 2013"/>
+    <tags>Machine Learning</tags>
+</entry>
+<entry category="awards">
+</entry>
+<entry category="education">
+    <entryInfo title="National University of Singapore" subheader="Bachelor of computing" duration="2010 - 2014"/>
+    <tags>machinelearning</tags>
+</entry>
+</entrybook>


### PR DESCRIPTION
These are the classes involved in AB4 storage:
![image](https://user-images.githubusercontent.com/35621759/47950492-18400900-df8e-11e8-82b6-b55fa3779ce3.png)

XmlAddressBook is created during **initialisation**.
It asks XmlFileStorage (not shown in diagram) to parse the XML data into an XmlSerializableAddressBook object.

XmlFileStorage does this via the [JAXB framework](https://docs.oracle.com/javase/8/docs/technotes/guides/xml/jaxb/index.html), which basically takes a class and does a mapping between the XML data and the members of the class. 

XmlSerializableAddressBook does some validation and returns an AddressBook.
XmlSerializableAddressBook has a list of XmlAdaptedPersons.

Similarly, I have added:
- XmlSerializableEntryBook
- XmlAdaptedEntryInfo
- XmlAdaptedEntryDescription
- XmlAdaptedResumeEntry, which is composed of XmlAdaptedEntryInfo and XmlAdaptedEntryDescription


**Data validation done**
XmlAdaptedResumeEntry will check that:
- Every entry in XML has a category element (**may be empty string**)
- Every entry in XML has a tag element (**may be empty string**)
- Every entry has a description element (**may be empty element**)

XmlAdaptedEntryInfo will check that:
- If an entry in XML has a EntryInfo tag, all three attributes (title, subheader, duration) must be present (**may be empty strings**)

XmlAdaptedDescription will check that:
- No checks done 

**Data validation to add**
- Do not allow empty string / whitespace for category?
- Do not allow empty string / whitespace for tag?
- For major entries, do not allow empty string / whitespace for entry info fields? 
- Do not allow empty element for description (at least one bullet) ? 
- Do not allow empty bullet elements? 

**To test this PR**
Save the following file in the `main` folder as `data.xml`
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

<entrybook>
<entry category="work">
    <entryInfo title="Facebook Internship" subheader="Coffee Boy" duration="Summer 2011"/>
    <entryDesc>
      <bullet>Implemented a scalable system of coffee delivery to mid and upper level executives. </bullet>
      <bullet> Personally oversaw daily coffee delivery to more than 20 remote and on-site teams. </bullet>
      <bullet> Went beyond my duties to provide additional donut delivery services. </bullet>
    </entryDesc>
    <tags>leadership</tags>
</entry>
<entry category="work">
    <entryInfo title="Carousell Internship" subheader="Donut Boy" duration="Summer 2010"/>
    <entryDesc>
      <bullet> Implemented a scalable system of donut delivery to mid and upper level executives. </bullet>
      <bullet> Personally oversaw daily donut delivery to more than 20 remote and on-site teams. </bullet>
      <bullet> Also established expertise in coffee delivery services. </bullet>
    </entryDesc>
    <tags>donuts</tags>
    <tags>management</tags>
</entry>
<entry category="project">
    <entryInfo title="Predictive analytics for traffic congestion" subheader="Intern" duration="Summer 2012"/>
    <entryDesc>
      <bullet>Applied machine learning on traffic patterns.</bullet>
    </entryDesc>
    <tags>machine_learning</tags>
</entry>
</entrybook>
```

Add the following _test code_ at the end of the `init` method in `MainApp.java`
```
        try {
            EntryBook entrybook =
            XmlUtil.getDataFromFile(Paths.get("data.xml"), XmlSerializableEntryBook.class).toModelType();

            entrybook.getEntryList().forEach(entry -> model.addEntry(entry));


        } catch (IllegalValueException e) { 
            System.out.println(e);
        }
```

The application should launch with the entries visible in the UI.