### PR TITLE
Add entry storage

### DIFF
--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryDescription.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryDescription.java
@@ -1,0 +1,58 @@
+package seedu.address.storage.entry;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.EntryDescription;
+
+/** A JAXB friendly version of EntryDescription */
+public class XmlAdaptedEntryDescription {
+
+    public static final String MESSAGE_MISSING_BULLETS = "Description element, if provided, cannot be empty.";
+
+    @XmlElement(name = "bullet")
+    private List<String> bullets;
+
+    /**
+     * Default constructor needed by JAXB
+     */
+    public XmlAdaptedEntryDescription() {}
+
+    /**
+     * Converts this jaxb-friendly adapted entry description object into the model's EntryDescription object.
+     * // TODO: Add data validation
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entry description.
+     */
+    public EntryDescription toModelType() throws IllegalValueException {
+        EntryDescription desc = new EntryDescription();
+
+        if (bullets == null) {
+            throw new IllegalValueException(MESSAGE_MISSING_BULLETS);
+        }
+
+        for (String bullet : bullets) {
+            // TODO: Validate bullet
+            desc.addBullet(bullet);
+        }
+
+        return desc;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedEntryInfo)) {
+            return false;
+        }
+
+        XmlAdaptedEntryDescription entryDescription = (XmlAdaptedEntryDescription) other;
+        return bullets.equals(entryDescription.bullets);
+
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryInfo.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedEntryInfo.java
@@ -1,0 +1,70 @@
+package seedu.address.storage.entry;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.EntryInfo;
+
+/** A JAXB friendly version of EntryInfo */
+public class XmlAdaptedEntryInfo {
+
+    private static final String MESSAGE_MISSING_ENTRY_INFO = "An entry is missing the %s field";
+
+    @XmlAttribute
+    private String title;
+    @XmlAttribute
+    private String subheader;
+    @XmlAttribute
+    private String duration;
+
+    public XmlAdaptedEntryInfo() {}
+
+    /**
+     * Converts this jaxb-friendly adapted entry info object into the model's EntryInfo object
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entry info
+     */
+    public EntryInfo toModelType() throws IllegalValueException {
+
+        /** If entryInfo has been specified in XML, all 3 fields must be provided */
+        if (title == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "title"));
+        }
+
+        if (subheader == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "subheader"));
+        }
+
+        if (duration == null) {
+            throw new IllegalValueException(String.format(MESSAGE_MISSING_ENTRY_INFO, "duration"));
+        }
+
+        List<String> toBeValidated = Arrays.asList(title, subheader, duration);
+
+        if (!EntryInfo.isValidEntryInfo(toBeValidated)) {
+            throw new IllegalValueException(EntryInfo.MESSAGE_ENTRYINFO_CONSTRAINTS);
+        }
+
+        return new EntryInfo(title, subheader, duration);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedEntryInfo)) {
+            return false;
+        }
+
+        XmlAdaptedEntryInfo otherAdaptedEntryInfo = (XmlAdaptedEntryInfo) other;
+        return Objects.equals(title, otherAdaptedEntryInfo.title)
+                 && Objects.equals(subheader, otherAdaptedEntryInfo.subheader)
+                 && Objects.equals(duration, otherAdaptedEntryInfo.duration);
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlAdaptedResumeEntry.java
+++ b/src/main/java/seedu/address/storage/entry/XmlAdaptedResumeEntry.java
@@ -1,0 +1,108 @@
+package seedu.address.storage.entry;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.category.Category;
+import seedu.address.model.entry.EntryDescription;
+import seedu.address.model.entry.EntryInfo;
+import seedu.address.model.entry.ResumeEntry;
+import seedu.address.model.tag.Tag;
+
+/**
+ * JAXB-friendly version of the ResumeEntry.
+ */
+public class XmlAdaptedResumeEntry {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Entry's %s field is missing!";
+
+    @XmlAttribute
+    private String category;
+    @XmlElement
+    private XmlAdaptedEntryInfo entryInfo;
+    @XmlElement
+    private XmlAdaptedEntryDescription entryDesc;
+    @XmlElement
+    private List<String> tags = new LinkedList<String>();
+
+    /**
+     * Constructs an XmlAdaptedPerson.
+     * This is the no-arg constructor that is required by JAXB.
+     */
+    public XmlAdaptedResumeEntry() {}
+
+
+    /**
+     * Converts this jaxb-friendly adapted resume entry object into the model's ResumeEntry object.
+     * // TODO: Add data validation
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted resume entry.
+     */
+    public ResumeEntry toModelType() throws IllegalValueException {
+
+        if (category == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                                                                  Category.class.getSimpleName()));
+        }
+
+        if (!Category.isValidCategoryName(category)) {
+            throw new IllegalValueException(Category.MESSAGE_CATE_CONSTRAINTS);
+        }
+
+        Category modelCategory = new Category(category);
+
+        /* tags are optional */
+        HashSet<Tag> modelTags = new HashSet<Tag>();
+
+        for (String t : tags) {
+            if (!Tag.isValidTagName(t)) {
+                throw new IllegalValueException(Tag.MESSAGE_TAG_CONSTRAINTS);
+            }
+
+            modelTags.add(new Tag(t));
+        }
+
+        /* entry info is optional */
+        EntryInfo modelEntryInfo;
+
+        if (entryInfo == null) {
+            modelEntryInfo = new EntryInfo();
+        } else {
+            modelEntryInfo = entryInfo.toModelType();
+        }
+
+        /* entry description is optional*/
+        if (entryDesc == null) {
+            return new ResumeEntry(modelCategory, modelEntryInfo, modelTags);
+        } else {
+
+            EntryDescription modelDescription = entryDesc.toModelType();
+            return new ResumeEntry(modelCategory, modelEntryInfo, modelTags, modelDescription);
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedResumeEntry)) {
+            return false;
+        }
+
+        XmlAdaptedResumeEntry otherResumeEntry = (XmlAdaptedResumeEntry) other;
+
+        return Objects.equals(category, otherResumeEntry.category)
+                && Objects.equals(entryInfo, otherResumeEntry.entryInfo)
+                && Objects.equals(entryDesc, otherResumeEntry.entryDesc)
+                && Objects.equals(tags, otherResumeEntry.tags);
+    }
+}

--- a/src/main/java/seedu/address/storage/entry/XmlSerializableEntryBook.java
+++ b/src/main/java/seedu/address/storage/entry/XmlSerializableEntryBook.java
@@ -1,0 +1,62 @@
+package seedu.address.storage.entry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.EntryBook;
+import seedu.address.model.entry.ResumeEntry;
+
+/**
+ * An Immutable EntryBook that is serializable to XML format
+ */
+@XmlRootElement(name = "entrybook")
+public class XmlSerializableEntryBook {
+
+    public static final String MESSAGE_DUPLICATE_ENTRY = "Entry list contains duplicate entries.";
+
+    @XmlElement(name = "entry")
+    private List<XmlAdaptedResumeEntry> resumeEntries;
+
+    /**
+     * Creates an empty XmlSerializableEntryBook.
+     * This empty constructor is required for marshalling.
+     */
+    public XmlSerializableEntryBook() {
+        resumeEntries = new ArrayList<>();
+    }
+
+
+    /**
+     * Converts this entrybook into the model's {@code EntryBook} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated or duplicates in the
+     * {@code XmlAdaptedResumeEntryBook}.
+     */
+    public EntryBook toModelType() throws IllegalValueException {
+        EntryBook entryBook = new EntryBook();
+        for (XmlAdaptedResumeEntry e : resumeEntries) {
+            ResumeEntry entry = e.toModelType();
+            if (entryBook.hasEntry(entry)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ENTRY);
+            }
+            entryBook.addEnty(entry);
+        }
+        return entryBook;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlSerializableEntryBook)) {
+            return false;
+        }
+        return resumeEntries.equals(((XmlSerializableEntryBook) other).resumeEntries);
+    }
+}

--- a/src/test/java/seedu/address/storage/entry/XmlSerializableEntryBookTest.java
+++ b/src/test/java/seedu/address/storage/entry/XmlSerializableEntryBookTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.ExpectedException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.EntryBook;
+import seedu.address.model.category.Category;
 import seedu.address.model.entry.EntryInfo;
 import seedu.address.testutil.TypicalEntrys;
 
@@ -21,6 +22,7 @@ public class XmlSerializableEntryBookTest {
     private static final Path TYPICAL_ENTRIES_FILE = TEST_DATA_FOLDER.resolve("typicalEntryBook.xml");
     private static final Path INVALID_ENTRYTITLE_FILE = TEST_DATA_FOLDER.resolve("invalidEntryTitle.xml");
     private static final Path MISSING_BULLETS_FILE = TEST_DATA_FOLDER.resolve("missingBullets.xml");
+    private static final Path MISSING_CATEGORY_FILE = TEST_DATA_FOLDER.resolve("missingCategory.xml");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -47,12 +49,25 @@ public class XmlSerializableEntryBookTest {
     }
 
     @Test
-    public void toModelType_invalidDescription_failure() throws Exception {
+    public void toModelType_missingBullets_failure() throws Exception {
         XmlSerializableEntryBook dataFromFile = XmlUtil.getDataFromFile(MISSING_BULLETS_FILE,
                 XmlSerializableEntryBook.class);
 
         thrown.expect(IllegalValueException.class);
         thrown.expectMessage(XmlAdaptedEntryDescription.MESSAGE_MISSING_BULLETS);
+
+        dataFromFile.toModelType();
+
+    }
+
+    @Test
+    public void toModelType_missingCategory_failure() throws Exception {
+        XmlSerializableEntryBook dataFromFile = XmlUtil.getDataFromFile(MISSING_CATEGORY_FILE,
+                XmlSerializableEntryBook.class);
+
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(String.format(XmlAdaptedResumeEntry.MISSING_FIELD_MESSAGE_FORMAT,
+                                                   Category.class.getSimpleName()));
 
         dataFromFile.toModelType();
 

--- a/src/test/java/seedu/address/storage/entry/XmlSerializableEntryBookTest.java
+++ b/src/test/java/seedu/address/storage/entry/XmlSerializableEntryBookTest.java
@@ -1,0 +1,62 @@
+package seedu.address.storage.entry;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.XmlUtil;
+import seedu.address.model.EntryBook;
+import seedu.address.model.entry.EntryInfo;
+import seedu.address.testutil.TypicalEntrys;
+
+public class XmlSerializableEntryBookTest {
+
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlSerializableEntryBookTest");
+    private static final Path TYPICAL_ENTRIES_FILE = TEST_DATA_FOLDER.resolve("typicalEntryBook.xml");
+    private static final Path INVALID_ENTRYTITLE_FILE = TEST_DATA_FOLDER.resolve("invalidEntryTitle.xml");
+    private static final Path MISSING_BULLETS_FILE = TEST_DATA_FOLDER.resolve("missingBullets.xml");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void toModelType_typicalEntriesFile_success() throws Exception {
+        XmlSerializableEntryBook dataFromFile = XmlUtil.getDataFromFile(TYPICAL_ENTRIES_FILE,
+                XmlSerializableEntryBook.class);
+        EntryBook entryBookFromFile = dataFromFile.toModelType();
+        EntryBook typicalEntryBook = TypicalEntrys.getTypicalEntryBook();
+        assertEquals(entryBookFromFile, typicalEntryBook);
+    }
+
+    @Test
+    public void toModelType_invalidEntryTitle_failure() throws Exception {
+        XmlSerializableEntryBook dataFromFile = XmlUtil.getDataFromFile(INVALID_ENTRYTITLE_FILE,
+                XmlSerializableEntryBook.class);
+
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(EntryInfo.MESSAGE_ENTRYINFO_CONSTRAINTS);
+
+        dataFromFile.toModelType();
+
+    }
+
+    @Test
+    public void toModelType_invalidDescription_failure() throws Exception {
+        XmlSerializableEntryBook dataFromFile = XmlUtil.getDataFromFile(MISSING_BULLETS_FILE,
+                XmlSerializableEntryBook.class);
+
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(XmlAdaptedEntryDescription.MESSAGE_MISSING_BULLETS);
+
+        dataFromFile.toModelType();
+
+    }
+
+
+}


### PR DESCRIPTION
Fixes #273 
With this PR,
The user defined XML is subject to the following conditions:

- Category attribute is compulsory for each entry, and must be valid as defined by `Category` class
- Entries may have 0 tag elements, but if they are provided, all tag names must be valid as defined by `Tag` class
- Entries may omit the entryInfo element, but if provided, all 3 attributes (title, subheader, duration) **must** be present and valid as defined by `EntryInfo` class
- Entries may omit the entryDesc element, but if provided, there must be at least one bullet element
- The XML cannot contain duplicate entries

Pending implementation:
- Validation of the bullet elements. Currently, empty string and whitespace will be accepted as bullets.

Sample XML:

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

<entrybook>
<entry category="work">
    <entryInfo title="Facebook Internship" subheader="Coffee Boy" duration="Summer 2011"/>
    <entryDesc>
      <bullet>Implemented a scalable system of coffee delivery to mid and upper level executives. </bullet>
      <bullet> Personally oversaw daily coffee delivery to more than 20 remote and on-site teams. </bullet>
      <bullet> Went beyond my duties to provide additional donut delivery services. </bullet>
    </entryDesc>
    <tags>leadership</tags>
</entry>
<entry category="work">
    <entryInfo title="Carousell Internship" subheader="Donut Boy" duration="Summer 2010"/>
    <tags>donuts</tags>
    <tags>management</tags>
</entry>
<entry category="awards">
</entry>
</entrybook>
```