### PR TITLE
Link awareness with ModelManager constructor

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -103,7 +103,7 @@ public class MainApp extends Application {
             initialData = new AddressBook();
         }
 
-        return new ModelManager(initialData, initialDataForEntryBook, userPrefs);
+        return new ModelManager(initialData, initialDataForEntryBook, userPrefs, SampleDataUtil.getSampleAwareness());
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -72,7 +72,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     public ModelManager() {
-        this(new AddressBook(), new EntryBook(), new UserPrefs(), SampleDataUtil.getSampleAwareness());
+        this(new AddressBook(), new EntryBook(), new UserPrefs(), new Awareness());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -51,9 +51,10 @@ public class ModelManager extends ComponentManager implements Model {
     private final CategoryManager categoryManager;
 
     /**
-     * Initializes a ModelManager with the given addressBook and userPrefs.
+     * Initializes a ModelManager with the given entrybook, userPrefs and awareness object
      */
-    public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyEntryBook entryBook, UserPrefs userPrefs) {
+    public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyEntryBook entryBook, UserPrefs userPrefs,
+                        Awareness awareness) {
         super();
         requireAllNonNull(addressBook, userPrefs);
 
@@ -62,7 +63,7 @@ public class ModelManager extends ComponentManager implements Model {
         versionedAddressBook = new VersionedAddressBook(addressBook);
         filteredPersons = new FilteredList<>(versionedAddressBook.getPersonList());
         loadedTemplate = Optional.empty();
-        awareness = SampleDataUtil.getSampleAwareness();
+        this.awareness = awareness;
         versionedEntryBook = new VersionedEntryBook(entryBook);
         filteredEntries = new FilteredList<>(versionedEntryBook.getEntryList());
 
@@ -71,7 +72,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     public ModelManager() {
-        this(new AddressBook(), new EntryBook(), new UserPrefs());
+        this(new AddressBook(), new EntryBook(), new UserPrefs(), SampleDataUtil.getSampleAwareness());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -30,7 +30,6 @@ import seedu.address.model.person.Person;
 import seedu.address.model.resume.Resume;
 import seedu.address.model.tag.TagManager;
 import seedu.address.model.template.Template;
-import seedu.address.model.util.SampleDataUtil;
 
 /**
  * Represents the in-memory model of the address book data.

--- a/src/main/java/seedu/address/model/awareness/Awareness.java
+++ b/src/main/java/seedu/address/model/awareness/Awareness.java
@@ -42,6 +42,11 @@ public class Awareness {
 
     }
 
+    /** Constructor to create an empty Awareness object */
+    public Awareness() {
+        this(new HashMap<String, String>(), new TreeSet<String>());
+    }
+
     /**
      * Given an expression, returns a possible Event name. An Event with this name may not actually exist.
      * For example, given the expression "cs", "computer science" is returned as an Event name.
@@ -118,6 +123,23 @@ public class Awareness {
      */
     public Optional<ResumeEntry> getContextualResumeEntry(String possibleEventName) {
         return Optional.ofNullable(nameToEntryMappings.get(possibleEventName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Awareness)) {
+            return false;
+        }
+
+        Awareness otherAwareness = (Awareness) other;
+
+        return this.dictionary.equals(otherAwareness.dictionary)
+                 && this.allFullPhrases.equals(otherAwareness.allFullPhrases)
+                 && this.nameToEntryMappings.equals(otherAwareness.nameToEntryMappings);
     }
 
 

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.storage.UserPrefsStorage;
 import seedu.address.storage.XmlSerializableAddressBook;
 import seedu.address.testutil.TestUtil;
@@ -92,7 +93,7 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = new ModelManager((model.getAddressBook()), model.getEntryBook(), new UserPrefs());
+        Model copy = new ModelManager((model.getAddressBook()), model.getEntryBook(), new UserPrefs(), new Awareness());
         ModelHelper.setFilteredList(copy, model.getFilteredPersonList());
         return copy;
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 
 
 public class LogicManagerTest {
@@ -89,7 +90,8 @@ public class LogicManagerTest {
      * @see #assertCommandBehavior(Class, String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<?> expectedException, String expectedMessage) {
-        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs(),
+                                                       new Awareness());
         assertCommandBehavior(expectedException, inputCommand, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddBulletCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddBulletCommandTest.java
@@ -22,12 +22,14 @@ import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.util.EntryBuilder;
 
 public class AddBulletCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                   new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -43,7 +45,8 @@ public class AddBulletCommandTest {
         String expectedMessage = String.format(AddBulletCommand.MESSAGE_ADDBULLET_SUCCESS, DESC_BULLET_FINANCIAL_HACK);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
+
         expectedModel.updateEntry(model.getFilteredEntryList().get(0), editedEntry);
         expectedModel.commitEntryBook();
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -12,6 +12,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -25,14 +26,15 @@ public class AddCommandIntegrationTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(), new Awareness());
     }
 
     @Test
     public void execute_newPerson_success() {
         Person validPerson = new PersonBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), getTypicalEntryBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                       new Awareness());
         expectedModel.addPerson(validPerson);
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -11,6 +11,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 
 public class ClearCommandTest {
 
@@ -27,8 +28,10 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                               new Awareness());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                       new Awareness());
         expectedModel.resetData(new AddressBook());
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/ContextCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ContextCommandTest.java
@@ -8,8 +8,8 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
+import seedu.address.model.*;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.util.SampleDataUtil;
 
 public class ContextCommandTest {
@@ -18,6 +18,8 @@ public class ContextCommandTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private CommandHistory commandHistory = new CommandHistory();
+
+    private final Awareness typicalAwareness = SampleDataUtil.getSampleAwareness();
 
     @Test
     public void constructor_nullExpression_throwsNullPointerException() {
@@ -33,8 +35,7 @@ public class ContextCommandTest {
 
     @Test
     public void execute_noMatchingResumeEntry_unableToAddResumeEntry() throws Exception {
-
-        Model model = new ModelManager();
+        Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
 
         thrown.expect(CommandException.class);
         thrown.expectMessage(String.format(ContextCommand.MESSAGE_NO_RESUME_ENTRY, "double degree programme"));
@@ -44,7 +45,7 @@ public class ContextCommandTest {
 
     @Test
     public void execute_matchingResumeEntry_successfulAdd() throws Exception {
-        Model model = new ModelManager();
+        Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
 
         String taResult = new ContextCommand("ta ma1101r").execute(model, commandHistory).feedbackToUser;
         assertEquals(taResult, String.format(AddEntryCommand.MESSAGE_SUCCESS, SampleDataUtil.MA1101R_TA));
@@ -55,7 +56,7 @@ public class ContextCommandTest {
 
     @Test
     public void execute_twiceSameExpression_duplicateEntry() throws Exception {
-        Model model = new ModelManager();
+        Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
 
         String taResult = new ContextCommand("ta ma1101r").execute(model, commandHistory).feedbackToUser;
         assertEquals(taResult, String.format(AddEntryCommand.MESSAGE_SUCCESS, SampleDataUtil.MA1101R_TA));
@@ -68,7 +69,7 @@ public class ContextCommandTest {
 
     @Test
     public void execute_differentExpression_duplicateEntry() throws Exception {
-        Model model = new ModelManager();
+        Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
 
         String taResult = new ContextCommand("ta ma1101r").execute(model, commandHistory).feedbackToUser;
         assertEquals(taResult, String.format(AddEntryCommand.MESSAGE_SUCCESS, SampleDataUtil.MA1101R_TA));

--- a/src/test/java/seedu/address/logic/commands/ContextCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ContextCommandTest.java
@@ -8,7 +8,11 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.*;
+import seedu.address.model.AddressBook;
+import seedu.address.model.EntryBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.awareness.Awareness;
 import seedu.address.model.util.SampleDataUtil;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -19,6 +19,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.person.Person;
 
 /**
@@ -27,7 +28,8 @@ import seedu.address.model.person.Person;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                   new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -38,7 +40,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(),
-                model.getEntryBook(), new UserPrefs());
+                model.getEntryBook(), new UserPrefs(), new Awareness());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
 
@@ -62,7 +64,8 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs(),
+                                                       new Awareness());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
@@ -88,7 +91,7 @@ public class DeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
         Model expectedModel = new ModelManager(model.getAddressBook(),
-                model.getEntryBook(), new UserPrefs());
+                model.getEntryBook(), new UserPrefs(), new Awareness());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
 
@@ -127,7 +130,8 @@ public class DeleteCommandTest {
     @Test
     public void executeUndoRedo_validIndexFilteredList_samePersonDeleted() throws Exception {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs(),
+                                                       new Awareness());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -36,7 +37,8 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                   new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -48,7 +50,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -71,7 +73,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
         expectedModel.updatePerson(lastPerson, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -87,7 +89,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -106,7 +108,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -167,7 +169,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
         expectedModel.updatePerson(personToEdit, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -210,7 +212,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new EntryBook(model.getEntryBook()), new UserPrefs());
+                new EntryBook(model.getEntryBook()), new UserPrefs(), new Awareness());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -20,14 +20,17 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                   new Awareness());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                           new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -13,6 +13,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -25,8 +26,10 @@ public class ListCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                         new Awareness());
+        expectedModel = new ModelManager(model.getAddressBook(), model.getEntryBook(), new UserPrefs(),
+                                                 new Awareness());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -13,12 +13,14 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 
 public class RedoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                         new Awareness());
     private final Model expectedModel = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.ui.testutil.EventsCollectorRule;
 
 /**
@@ -32,9 +33,9 @@ public class SelectCommandTest {
     public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
 
     private Model model = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SelectEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectEntryCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.ui.testutil.EventsCollectorRule;
 
 public class SelectEntryCommandTest {
@@ -28,9 +29,9 @@ public class SelectEntryCommandTest {
     public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
 
     private Model model = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagAddCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.category.Category;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.tag.Tag;
@@ -83,9 +84,12 @@ public class TagAddCommandTest {
 
     @Test
     public void execute_addTags_tagsAdded() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         tags.add(new Tag("python"));
@@ -104,9 +108,12 @@ public class TagAddCommandTest {
 
     @Test
     public void execute_addCategory_categoryAdded() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         Category category = new Category("fb");

--- a/src/test/java/seedu/address/logic/commands/TagListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagListCommandTest.java
@@ -17,13 +17,16 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code TagListCommand}.
  */
 public class TagListCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                   new Awareness());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                           new Awareness());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagRetagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagRetagCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.category.Category;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.tag.Tag;
@@ -74,9 +75,12 @@ public class TagRetagCommandTest {
 
     @Test
     public void execute_category_added() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         Category category = new Category("fb");
@@ -93,9 +97,12 @@ public class TagRetagCommandTest {
 
     @Test
     public void execute_categoryAndTags_added() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         tags.add(new Tag("intern"));

--- a/src/test/java/seedu/address/logic/commands/TagRmCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagRmCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.tag.Tag;
 
@@ -79,9 +80,12 @@ public class TagRmCommandTest {
 
     @Test
     public void execute_rmTags_tagsRemoved() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         tags.add(new Tag("java"));
@@ -100,9 +104,12 @@ public class TagRmCommandTest {
 
     @Test
     public void execute_rmTags_allRemoved() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         Index index = Index.fromZeroBased(0);
@@ -120,9 +127,12 @@ public class TagRmCommandTest {
 
     @Test
     public void execute_rmTags_nothingRemoved() {
-        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(
-                new AddressBook(model.getAddressBook()), new EntryBook(model.getEntryBook()), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), getDefaultEntryBook(), new UserPrefs(),
+                                               new Awareness());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                                                       new EntryBook(model.getEntryBook()), new UserPrefs(),
+                                                       new Awareness());
 
         Set<Tag> tags = new HashSet<Tag>();
         tags.add(new Tag("python"));

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -13,13 +13,15 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.util.EntryBuilder;
 
 public class UndoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs(),
+                                                         new Awareness());
     private final Model expectedModel = new ModelManager(getTypicalAddressBook(),
-            getTypicalEntryBook(), new UserPrefs());
+            getTypicalEntryBook(), new UserPrefs(), new Awareness());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
+++ b/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
@@ -9,10 +9,17 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.events.ui.ContextUpdateEvent;
+import seedu.address.model.AddressBook;
+import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.awareness.Awareness;
+import seedu.address.model.util.SampleDataUtil;
 
 public class AwarenessServiceTest {
+
+    private static final Awareness typicalAwareness = SampleDataUtil.getSampleAwareness();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -35,7 +42,7 @@ public class AwarenessServiceTest {
 
     @Test
     public void observe_relevantInput() {
-        Model model = new ModelManager();
+        Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
         AwarenessService awarenessService = new AwarenessService(model);
 
         ContextUpdateEvent actual = (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r").get();

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.model.awareness.Awareness;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.resume.Resume;
 import seedu.address.testutil.AddressBookBuilder;
@@ -122,12 +123,13 @@ public class ModelManagerTest {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
+        Awareness awareness = new Awareness();
         EntryBook entryBook = new EntryBookBuilder().withEntry(WORK_FACEBOOK).withEntry(NUS_EDUCATION).build();
         EntryBook differentEntryBook = new EntryBook();
 
         // same values -> returns true
-        modelManager = new ModelManager(addressBook, entryBook, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(addressBook, entryBook, userPrefs);
+        modelManager = new ModelManager(addressBook, entryBook, userPrefs, awareness);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, entryBook, userPrefs, awareness);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -140,12 +142,13 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, differentEntryBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, differentEntryBook, userPrefs,
+                                                                 awareness)));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, entryBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, entryBook, userPrefs, awareness)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -154,6 +157,6 @@ public class ModelManagerTest {
         // different userPrefs -> returns true
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setEntryBookFilePath(Paths.get("differentFilePath"));
-        assertTrue(modelManager.equals(new ModelManager(addressBook, entryBook, differentUserPrefs)));
+        assertTrue(modelManager.equals(new ModelManager(addressBook, entryBook, differentUserPrefs, awareness)));
     }
 }


### PR DESCRIPTION
In this PR, I am adding Awareness as an argument to ModelManager's constructor.
I have updated the affected tests.
I have updated each test in a single commit each --> hope it makes it easier to review.

Updated tests:
@ongspxm: TagListCommand, TagAddCommand, TagRetagCommand, TagRemoveCommand
@jhengy : AddBulletCommand, SelectEntryCommand
@anubh-v : ContextCommand, AwarenessServiceTest
General: LogicManager test, ModelManager test, TestApp

Tests for equals method in Awareness with be added in a separate PR