### PR TITLE
ModelManager and Model: deleteEntry() method

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -175,7 +175,7 @@ Example:
 Edits the 1st entry by replacing its 1st bullet description with "implement scalable application for data visualization using java".
 
 
-=== Deleting an entry: `deleteEntry` [Coming in v1.4]
+=== Deleting an entry: `deleteEntry` 
 
 Deletes the entry at the specified index. +
 Format: `deleteEntry INDEX`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -175,7 +175,7 @@ Example:
 Edits the 1st entry by replacing its 1st bullet description with "implement scalable application for data visualization using java".
 
 
-=== Deleting an entry: `deleteEntry` 
+=== Deleting an entry: `deleteEntry`
 
 Deletes the entry at the specified index. +
 Format: `deleteEntry INDEX`

--- a/src/main/java/seedu/address/logic/commands/exceptions/DeleteEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/DeleteEntryCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.entry.ResumeEntry;
+
+/**
+ * Deletes an entry from displayed entry list.
+ */
+public class DeleteEntryCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteEntry";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the entry identified by the index number used in the displayed entry list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_ENTRY_SUCCESS = "Deleted Entry: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteEntryCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<ResumeEntry> lastShownList = model.getFilteredEntryList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+        }
+
+        ResumeEntry entryToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteEntry(entryToDelete);
+        model.commitEntryBook();
+        return new CommandResult(String.format(MESSAGE_DELETE_ENTRY_SUCCESS, entryToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteEntryCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteEntryCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SelectEntryCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.exceptions.DeleteEntryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -56,6 +57,9 @@ public class AddressBookParser {
         switch (commandWord) {
         case AddEntryCommand.COMMAND_WORD:
             return new AddEntryCommandParser().parse(arguments);
+
+        case DeleteEntryCommand.COMMAND_WORD:
+            return new DeleteEntryCommandParser().parse(arguments);
 
         case AddBulletCommand.COMMAND_WORD:
             return new AddBulletCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteEntryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteEntryCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.DeleteEntryCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * parses the given arguments into a DeleteEntryCommand.
+ */
+public class DeleteEntryCommandParser implements Parser<DeleteEntryCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteEntryCommand
+     * and returns an DeleteEntryCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteEntryCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteEntryCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEntryCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,6 +50,13 @@ public interface Model {
     void deletePerson(Person target);
 
     /**
+     * Deletes the given entry.
+     * The entry must exist in the entry book.
+     */
+    void deleteEntry(ResumeEntry target);
+
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -126,6 +126,12 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public void deleteEntry(ResumeEntry target) {
+        versionedEntryBook.removeEntry(target);
+        indicateEntryBookChanged();
+    }
+
+    @Override
     public void addPerson(Person person) {
         versionedAddressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -136,6 +136,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void deleteEntry(ResumeEntry target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updatePerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEntryCommandTest.java
@@ -137,6 +137,11 @@ public class AddEntryCommandTest {
         }
 
         @Override
+        public void deleteEntry(ResumeEntry target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updatePerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/DeleteEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEntryCommandTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalEntrys.getTypicalEntryBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.DeleteEntryCommand;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.entry.ResumeEntry;
+
+public class DeleteEntryCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEntryBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        ResumeEntry entryToDelete = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteEntryCommand deleteEntryCommand = new DeleteEntryCommand(INDEX_FIRST_ENTRY);
+
+        String expectedMessage = String.format(DeleteEntryCommand.MESSAGE_DELETE_ENTRY_SUCCESS, entryToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(),
+                model.getEntryBook(), new UserPrefs());
+        expectedModel.deleteEntry(entryToDelete);
+        expectedModel.commitEntryBook();
+
+        assertCommandSuccess(deleteEntryCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEntryList().size() + 1);
+        DeleteEntryCommand deleteEntryCommand = new DeleteEntryCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteEntryCommand, model, commandHistory, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+
+    @Test
+    public void equals() {
+        DeleteEntryCommand deleteFirstCommand = new DeleteEntryCommand(INDEX_FIRST_ENTRY);
+        DeleteEntryCommand deleteSecondCommand = new DeleteEntryCommand(INDEX_SECOND_ENTRY);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteEntryCommand deleteFirstCommandCopy = new DeleteEntryCommand(INDEX_FIRST_ENTRY);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different entry -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.MakeCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectEntryCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.exceptions.DeleteEntryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -62,6 +63,13 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteEntry() throws Exception {
+        DeleteEntryCommand command = (DeleteEntryCommand) parser.parseCommand(
+                DeleteEntryCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new DeleteEntryCommand(INDEX_FIRST_ENTRY), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteEntryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteEntryCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.exceptions.DeleteEntryCommand;
+
+public class DeleteEntryCommandParserTest {
+    private DeleteEntryCommandParser parser = new DeleteEntryCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteEntryCommand() {
+        assertParseSuccess(parser, "1", new DeleteEntryCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEntryCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
- fixes #269 
-  this PR enables Resumaker to execute `deleteEntry INDEX` to remove an entry the displayed entry list
-