### PR TITLE
Trigger EntryBook loading in MainApp

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -2,6 +2,7 @@ package seedu.address;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -34,6 +35,7 @@ import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
 import seedu.address.storage.UserPrefsStorage;
 import seedu.address.storage.XmlAddressBookStorage;
+import seedu.address.storage.entry.XmlEntryBookStorage;
 import seedu.address.ui.Ui;
 import seedu.address.ui.UiManager;
 
@@ -76,6 +78,7 @@ public class MainApp extends Application {
         ui = new UiManager(logic, config, userPrefs);
 
         initEventsCenter();
+
     }
 
     /**
@@ -84,10 +87,11 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, UserPrefs userPrefs) {
+
+        // need to update system tests before these can be removed
         Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
-        // hardcoded for now, to be implemented when storage component is completed
-        ReadOnlyEntryBook initialDataForEntryBook = new EntryBook();
+
         try {
             addressBookOptional = storage.readAddressBook();
             initialData = addressBookOptional.orElseGet(() -> {
@@ -102,6 +106,30 @@ public class MainApp extends Application {
             logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
             initialData = new AddressBook();
         }
+
+
+        // need to update system tests before these can be removed
+        Optional<ReadOnlyEntryBook> entryBookOptional;
+        ReadOnlyEntryBook initialDataForEntryBook;
+
+        // filepath to the entrybook xml is hardcoded for now
+        Path entryBookPath = Paths.get("resume-data.xml");
+
+        try {
+            entryBookOptional = new XmlEntryBookStorage(entryBookPath).readEntryBook();
+            initialDataForEntryBook = entryBookOptional.orElseGet(() -> {
+                logger.info("Data file not found. Will be starting with a sample entrybook");
+                return SampleDataUtil.getSampleEntryBook();
+            }
+            );
+        } catch (DataConversionException e) {
+            logger.warning("Data file not in the correct format. Will be starting with an empty entrybook");
+            initialDataForEntryBook = new EntryBook();
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the file. Will be starting with an empty entrybook");
+            initialDataForEntryBook = new EntryBook();
+        }
+
 
         return new ModelManager(initialData, initialDataForEntryBook, userPrefs, SampleDataUtil.getSampleAwareness());
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -8,7 +8,9 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.EntryBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.awareness.Awareness;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.person.Address;
@@ -80,6 +82,15 @@ public class SampleDataUtil {
             sampleAb.addPerson(samplePerson);
         }
         return sampleAb;
+    }
+
+    public static ReadOnlyEntryBook getSampleEntryBook() {
+        EntryBook sampleEb = new EntryBook();
+        sampleEb.addEnty(MA1101R_TA);
+        sampleEb.addEnty(COMP_CLUB_EXCO);
+        sampleEb.addEnty(NUS_CS2103T);
+
+        return sampleEb;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/entry/EntryBookStorage.java
+++ b/src/main/java/seedu/address/storage/entry/EntryBookStorage.java
@@ -1,0 +1,22 @@
+package seedu.address.storage.entry;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.model.ReadOnlyEntryBook;
+
+/**
+ * Represents a storage for {@link seedu.address.model.EntryBook}.
+ */
+public interface EntryBookStorage {
+
+    /**
+     * Returns EntryBook data as a {@link seedu.address.model.ReadOnlyEntryBook}.
+     *   Returns {@code Optional.empty()} if storage file is not found.
+     * @throws DataConversionException if the data in storage is not in the expected format.
+     * @throws IOException if there was any problem when reading from the storage.
+     */
+    Optional<ReadOnlyEntryBook> readEntryBook() throws DataConversionException, IOException;
+
+}

--- a/src/main/java/seedu/address/storage/entry/XmlEntryBookStorage.java
+++ b/src/main/java/seedu/address/storage/entry/XmlEntryBookStorage.java
@@ -8,14 +8,13 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import javax.xml.bind.JAXBException;
+
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.ReadOnlyEntryBook;
-import seedu.address.storage.XmlFileStorage;
-
-import javax.xml.bind.JAXBException;
 
 /**
  * A class to access entrybook data stored as an xml file on the hard disk.

--- a/src/main/java/seedu/address/storage/entry/XmlEntryBookStorage.java
+++ b/src/main/java/seedu/address/storage/entry/XmlEntryBookStorage.java
@@ -1,0 +1,55 @@
+package seedu.address.storage.entry;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.XmlUtil;
+import seedu.address.model.ReadOnlyEntryBook;
+import seedu.address.storage.XmlFileStorage;
+
+import javax.xml.bind.JAXBException;
+
+/**
+ * A class to access entrybook data stored as an xml file on the hard disk.
+ */
+public class XmlEntryBookStorage implements EntryBookStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(XmlEntryBookStorage.class);
+
+    private Path filePath;
+
+    public XmlEntryBookStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public Optional<ReadOnlyEntryBook> readEntryBook() throws DataConversionException, IOException {
+        requireNonNull(filePath);
+
+        if (!Files.exists(filePath)) {
+            logger.info("Entrybook file " + filePath + " not found");
+            return Optional.empty();
+        }
+
+        try {
+            XmlSerializableEntryBook xmlEntryBook = XmlUtil.getDataFromFile(filePath, XmlSerializableEntryBook.class);
+
+            return Optional.of(xmlEntryBook.toModelType());
+        } catch (JAXBException jaxbe) {
+            logger.info("There is a problem in the XML formatting in " + filePath + ": " + jaxbe.getMessage());
+            throw new DataConversionException(jaxbe);
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #281 
With this PR, we can
load an entrybook from an XML file with filename `resume-data.xml` **in the same folder as the JAR**.

Pending Issues:
- Need to integrate XmlEntryBookStorage into Storage facade 
- Need to obtain filepath from UserPrefsStorage rather than hardcoding
- Need to update system tests so we can *remove the code that load AB4 data*


Follow this format for the XML:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

<entrybook>
<entry category="work">
    <entryInfo title="Facebook Internship" subheader="Coffee Boy" duration="Summer 2011"/>
    <entryDesc>
      <bullet>Implemented a scalable system of coffee delivery to mid and upper level executives. </bullet>
      <bullet> Personally oversaw daily coffee delivery to more than 20 remote and on-site teams. </bullet>
      <bullet> Went beyond my duties to provide additional donut delivery services. </bullet>
    </entryDesc>
    <tags>leadership</tags>
</entry>
<entry category="work">
    <entryInfo title="Carousell Internship" subheader="Donut Boy" duration="Summer 2010"/>
    <tags>donuts</tags>
    <tags>management</tags>
</entry>
<entry category="awards">
</entry>
</entrybook>
```