### PR TITLE
Eliminate Optional anti-pattern in ModelManager

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -221,7 +221,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public Optional<Template> getLoadedTemplate() {
-        return Optional.of(loadedTemplate);
+        return Optional.ofNullable(loadedTemplate);
         //will be up to the Generation part to raise NewResultAvailableEvent to say no template loaded
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -39,7 +39,7 @@ public class ModelManager extends ComponentManager implements Model {
     private final VersionedAddressBook versionedAddressBook;
     private final FilteredList<Person> filteredPersons;
     private final Awareness awareness;
-    private Optional<Template> loadedTemplate;
+    private Template loadedTemplate;
     private Resume lastGeneratedResume;
     private final VersionedEntryBook versionedEntryBook;
     private final FilteredList<ResumeEntry> filteredEntries;
@@ -60,7 +60,7 @@ public class ModelManager extends ComponentManager implements Model {
 
         versionedAddressBook = new VersionedAddressBook(addressBook);
         filteredPersons = new FilteredList<>(versionedAddressBook.getPersonList());
-        loadedTemplate = Optional.empty();
+        loadedTemplate = null;
         this.awareness = awareness;
         versionedEntryBook = new VersionedEntryBook(entryBook);
         filteredEntries = new FilteredList<>(versionedEntryBook.getEntryList());
@@ -221,7 +221,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public Optional<Template> getLoadedTemplate() {
-        return loadedTemplate;
+        return Optional.of(loadedTemplate);
         //will be up to the Generation part to raise NewResultAvailableEvent to say no template loaded
     }
 
@@ -313,13 +313,13 @@ public class ModelManager extends ComponentManager implements Model {
     public void handleTemplateLoadedEvent(TemplateLoadedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event,
                 "Template loaded from " + event.filepath.toString() + " to Model"));
-        loadedTemplate = Optional.of(event.getTemplate());
+        loadedTemplate = event.getTemplate();
     }
 
     @Subscribe
     public void handleTemplateLoadingExceptionEvent(TemplateLoadingExceptionEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event, "Exception when attempting to load template from "
                 + event.filepath.toString()));
-        loadedTemplate = Optional.empty();
+        loadedTemplate = null;
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -290,7 +290,8 @@ public class ModelManager extends ComponentManager implements Model {
                 && filteredEntries.equals(other.filteredEntries)
                 && categoryManager.equals(other.categoryManager)
                 && tagManager.equals(other.tagManager)
-                && loadedTemplate.equals(other.loadedTemplate)/*
+                && (loadedTemplate == other.loadedTemplate
+                || loadedTemplate.equals(other.loadedTemplate))/*
                 && awareness.equals(other.awareness)
                 && lastGeneratedResume.equals(other.lastGeneratedResume)*/;
     }


### PR DESCRIPTION
In line with the original purpose of `Optional`, `ModelManager` now stores `loadedTemplate` as a `Template` rather than `Optional<Template>`, and wraps the `Template` in an `Optional` in the getter method instead.