### PR TITLE
EntryBuilder Cannot Set Invalid Fields for EntryInfo

### DIFF
--- a/src/main/java/seedu/address/model/entry/EntryInfo.java
+++ b/src/main/java/seedu/address/model/entry/EntryInfo.java
@@ -41,17 +41,6 @@ public class EntryInfo {
     }
 
     /**
-     * checks if any of the fields is of invalid format.
-     * @throws IllegalArgumentException with error message MESSAGE_ENTRYINFO_CONSTRAINTS if invalid format is detected.
-     */
-    public void checkArguments(String title, String subtitle, String duration) {
-        checkArgument(isValidEntryInfoField(title), MESSAGE_ENTRYINFO_CONSTRAINTS);
-        checkArgument(isValidEntryInfoField(subtitle), MESSAGE_ENTRYINFO_CONSTRAINTS);
-        checkArgument(isValidEntryInfoField(duration), MESSAGE_ENTRYINFO_CONSTRAINTS);
-
-    }
-
-    /**
      * precond: entryInfo must not contain any null element
      * @param entryInfo list containing title, subHeader, duration. Can be empty
      */
@@ -88,6 +77,18 @@ public class EntryInfo {
     public static boolean isValidEntryInfo(List<String> entryInfo) {
         return entryInfo.stream().allMatch(s -> isValidEntryInfoField(s));
     }
+
+    /**
+     * checks if any of the fields is of invalid format.
+     * @throws IllegalArgumentException with error message MESSAGE_ENTRYINFO_CONSTRAINTS if invalid format is detected.
+     */
+    public void checkArguments(String title, String subtitle, String duration) {
+        checkArgument(isValidEntryInfoField(title), MESSAGE_ENTRYINFO_CONSTRAINTS);
+        checkArgument(isValidEntryInfoField(subtitle), MESSAGE_ENTRYINFO_CONSTRAINTS);
+        checkArgument(isValidEntryInfoField(duration), MESSAGE_ENTRYINFO_CONSTRAINTS);
+
+    }
+
     /**
      * @return Title of the entry.
      */

--- a/src/main/java/seedu/address/model/entry/EntryInfo.java
+++ b/src/main/java/seedu/address/model/entry/EntryInfo.java
@@ -34,9 +34,21 @@ public class EntryInfo {
      */
     public EntryInfo(String title, String subheader, String duration) {
         requireAllNonNull(title, subheader, duration);
+        checkArguments(title, subheader, duration);
         entryInfo.add(title);
         entryInfo.add(subheader);
         entryInfo.add(duration);
+    }
+
+    /**
+     * checks if any of the fields is of invalid format.
+     * @throws IllegalArgumentException with error message MESSAGE_ENTRYINFO_CONSTRAINTS if invalid format is detected.
+     */
+    public void checkArguments(String title, String subtitle, String duration) {
+        checkArgument(isValidEntryInfoField(title), MESSAGE_ENTRYINFO_CONSTRAINTS);
+        checkArgument(isValidEntryInfoField(subtitle), MESSAGE_ENTRYINFO_CONSTRAINTS);
+        checkArgument(isValidEntryInfoField(duration), MESSAGE_ENTRYINFO_CONSTRAINTS);
+
     }
 
     /**

--- a/src/main/java/seedu/address/model/entry/EntryInfo.java
+++ b/src/main/java/seedu/address/model/entry/EntryInfo.java
@@ -1,5 +1,6 @@
 package seedu.address.model.entry;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.commons.util.StringUtil.isEmptyString;
@@ -103,6 +104,8 @@ public class EntryInfo {
      * set title of the entry
      */
     public void setTitle(String title) {
+        requireNonNull(title);
+        checkArgument(isValidEntryInfoField(title), MESSAGE_ENTRYINFO_CONSTRAINTS);
         entryInfo.set(0, title);
     }
 
@@ -111,6 +114,8 @@ public class EntryInfo {
      * set subHeader of the entry
      */
     public void setSubHeader(String subHeader) {
+        requireNonNull(subHeader);
+        checkArgument(isValidEntryInfoField(subHeader), MESSAGE_ENTRYINFO_CONSTRAINTS);
         entryInfo.set(1, subHeader);
     }
 
@@ -119,6 +124,8 @@ public class EntryInfo {
      * set duration of the entry
      */
     public void setDuration(String duration) {
+        requireNonNull(duration);
+        checkArgument(isValidEntryInfoField(duration), MESSAGE_ENTRYINFO_CONSTRAINTS);
         entryInfo.set(2, duration);
     }
 

--- a/src/main/java/seedu/address/model/entry/EntryInfo.java
+++ b/src/main/java/seedu/address/model/entry/EntryInfo.java
@@ -82,7 +82,7 @@ public class EntryInfo {
      * checks if any of the fields is of invalid format.
      * @throws IllegalArgumentException with error message MESSAGE_ENTRYINFO_CONSTRAINTS if invalid format is detected.
      */
-    public void checkArguments(String title, String subtitle, String duration) {
+    private void checkArguments(String title, String subtitle, String duration) {
         checkArgument(isValidEntryInfoField(title), MESSAGE_ENTRYINFO_CONSTRAINTS);
         checkArgument(isValidEntryInfoField(subtitle), MESSAGE_ENTRYINFO_CONSTRAINTS);
         checkArgument(isValidEntryInfoField(duration), MESSAGE_ENTRYINFO_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -37,7 +37,7 @@ public class SampleDataUtil {
                                                      .withCategory("nonacademics")
                                                      .withTitle("Computing Club Executive Committee Member")
                                                      .withDuration("2010 Semester 1 and 2")
-                                                     .withSubHeader("Organised the club's budget")
+                                                     .withSubHeader("Organised budget of the club")
                                                      .withTags("leadership", "management", "entrepreneurship")
                                                      .build();
 


### PR DESCRIPTION
problem: EntryBuilder can set invalid EntryInfo fields, i.e. empty string to title, subtitle.duration.