### PR TITLE
Fix Context bar "lagging" by one character

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,6 +1,5 @@
 package seedu.address.ui;
 
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import javafx.beans.property.StringProperty;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,7 +1,9 @@
 package seedu.address.ui;
 
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
@@ -33,9 +35,8 @@ public class CommandBox extends UiPart<Region> {
     public CommandBox(Logic logic) {
         super(FXML);
         this.logic = logic;
-        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
-        commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
         historySnapshot = logic.getHistorySnapshot();
+        initListeners();
     }
 
     /**
@@ -155,6 +156,20 @@ public class CommandBox extends UiPart<Region> {
         }
 
         styleClass.add(ERROR_STYLE_CLASS);
+    }
+
+    /**
+     * Initialises all the listeners attached to the command box's commandTextField.
+     */
+    private void initListeners() {
+
+        StringProperty commandLineContent = commandTextField.textProperty();
+
+        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
+        commandLineContent.addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        // triggers all command line observers in logic
+        commandLineContent.addListener((observableValue, oldValue, newValue) -> triggerObservers(newValue));
     }
 
 }


### PR DESCRIPTION
Fixes #313 

Resolution:
Instead of triggering the logic observers on every keypress, I trigger them when the StringProperty of the CommandBox has been changed.

To do this, I attached a listener of the CommandBox's StringProperty.
I consolidated the 2 listeners into a separate `initListeners` method called during construction of CommandBox