### PR TITLE
Fix awareness observer parsing bug + clearer message for user + related tests

### DIFF
--- a/src/main/java/seedu/address/logic/observers/AwarenessService.java
+++ b/src/main/java/seedu/address/logic/observers/AwarenessService.java
@@ -13,8 +13,8 @@ import seedu.address.model.Model;
 /** Represents the service that continually informs the user about ResuMaker's guess */
 public class AwarenessService implements CmdLineObserver {
 
-    public static final String MESSAGE_AVAILABLE_ENTRY = "Resume entry available for: %s";
-    public static final String MESSAGE_NO_ENTRY = "No resume entry for: %s";
+    public static final String MESSAGE_AVAILABLE_ENTRY = "Pre-filled Resume entry available for: %s";
+    public static final String MESSAGE_NO_ENTRY = "No pre-filled resume entry for: %s";
     private static final String COMMAND_WORD = "nus";
 
     private final Model model;

--- a/src/main/java/seedu/address/logic/observers/AwarenessService.java
+++ b/src/main/java/seedu/address/logic/observers/AwarenessService.java
@@ -1,9 +1,10 @@
 package seedu.address.logic.observers;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.AddressBookParser.BASIC_COMMAND_FORMAT;
 
-import java.util.Arrays;
 import java.util.Optional;
+import java.util.regex.Matcher;
 
 import seedu.address.commons.events.BaseEvent;
 import seedu.address.commons.events.ui.ContextUpdateEvent;
@@ -14,7 +15,6 @@ public class AwarenessService implements CmdLineObserver {
 
     public static final String MESSAGE_AVAILABLE_ENTRY = "Resume entry available for: %s";
     public static final String MESSAGE_NO_ENTRY = "No resume entry for: %s";
-    private static final String SPACE = " ";
     private static final String COMMAND_WORD = "nus";
 
     private final Model model;
@@ -26,16 +26,21 @@ public class AwarenessService implements CmdLineObserver {
 
     @Override
     public Optional<BaseEvent> observe(String currentInput) {
-        // TODO Make this method body more readable
-        String command = currentInput.split(SPACE)[0];
 
-        if (!command.equals(COMMAND_WORD)) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(currentInput.trim());
+
+        if (!matcher.matches()) {
             return Optional.empty();
         }
 
-        String args = String.join(SPACE, Arrays.copyOfRange(currentInput.split(SPACE), 1,
-                                                                    currentInput.split(SPACE).length));
-        String possibleEvent = model.getPossibleEventName(args);
+        final String commandWord = matcher.group("commandWord");
+        final String trimmedArgs = matcher.group("arguments").trim();
+
+        if (!commandWord.equals(COMMAND_WORD)) {
+            return Optional.empty();
+        }
+
+        final String possibleEvent = model.getPossibleEventName(trimmedArgs);
 
         if (model.getContextualResumeEntry(possibleEvent).isPresent()) {
             return Optional.of(new ContextUpdateEvent(String.format(MESSAGE_AVAILABLE_ENTRY, possibleEvent)));

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -38,7 +38,7 @@ public class AddressBookParser {
     /**
      * Used for initial separation of command word and args.
      */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    public static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/seedu/address/model/awareness/Awareness.java
+++ b/src/main/java/seedu/address/model/awareness/Awareness.java
@@ -37,13 +37,6 @@ public class Awareness {
         this(new Dictionary(), new TreeMap<String, ResumeEntry>());
     }
 
-    /** Deprecated constructor. Required because the Awareness storage code still uses this constructor.
-     *  Will be removed very soon.
-     */
-    public Awareness(HashMap<String, String> dictionary, TreeSet<String> allEventNames) {
-        // this constructor has been deprecated. It will be removed very soon.
-    }
-
     /**
      * Given an expression, returns a possible Event name. An Event with this name may not actually exist.
      * For example, given the expression "cs", "computer science" is returned as an Event name.

--- a/src/main/java/seedu/address/model/awareness/Awareness.java
+++ b/src/main/java/seedu/address/model/awareness/Awareness.java
@@ -2,10 +2,8 @@ package seedu.address.model.awareness;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 import seedu.address.model.entry.ResumeEntry;
 

--- a/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
+++ b/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
@@ -53,19 +53,19 @@ public class AwarenessServiceTest {
 
         ContextUpdateEvent exactMatch = (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r").get();
 
-        ContextUpdateEvent leftTrailingSpaces =
+        ContextUpdateEvent trailingSpacesInput =
                 (ContextUpdateEvent) awarenessService.observe("  nus ta ma1101r").get();
 
-        ContextUpdateEvent rightTrailingSpaces =
+        ContextUpdateEvent leadingSpacesInput =
                 (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r    ").get();
 
-        ContextUpdateEvent bothTrailingSpaces =
+        ContextUpdateEvent paddedSpacesInput =
                (ContextUpdateEvent) awarenessService.observe("   nus ta ma1101r    ").get();
 
         assertEquals(exactMatch.message, expected.message);
-        assertEquals(leftTrailingSpaces.message, expected.message);
-        assertEquals(rightTrailingSpaces.message, expected.message);
-        assertEquals(bothTrailingSpaces.message, expected.message);
+        assertEquals(trailingSpacesInput.message, expected.message);
+        assertEquals(leadingSpacesInput.message, expected.message);
+        assertEquals(paddedSpacesInput.message, expected.message);
 
     }
 

--- a/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
+++ b/src/test/java/seedu/address/logic/observers/AwarenessServiceTest.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.observers;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.NoSuchElementException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,26 +30,43 @@ public class AwarenessServiceTest {
     }
 
     @Test
-    public void observe_miscInput() {
-        thrown.expect(NoSuchElementException.class);
+    public void observe_irrelevantInput() {
 
         Model model = new ModelManager();
         AwarenessService awarenessService = new AwarenessService(model);
-        awarenessService.observe("test input").get();
 
+        assertFalse(awarenessService.observe("test input").isPresent());
+        assertFalse(awarenessService.observe("                ").isPresent());
+        assertFalse(awarenessService.observe("       test         ").isPresent());
+        assertFalse(awarenessService.observe("").isPresent());
     }
+
 
     @Test
     public void observe_relevantInput() {
         Model model = new ModelManager(new AddressBook(), new EntryBook(), new UserPrefs(), typicalAwareness);
         AwarenessService awarenessService = new AwarenessService(model);
 
-        ContextUpdateEvent actual = (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r").get();
-
         ContextUpdateEvent expected = new ContextUpdateEvent(String.format(AwarenessService.MESSAGE_AVAILABLE_ENTRY,
                                                                                    "teaching assistant ma1101r"));
 
-        assertEquals(actual.message, expected.message);
+
+        ContextUpdateEvent exactMatch = (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r").get();
+
+        ContextUpdateEvent leftTrailingSpaces =
+                (ContextUpdateEvent) awarenessService.observe("  nus ta ma1101r").get();
+
+        ContextUpdateEvent rightTrailingSpaces =
+                (ContextUpdateEvent) awarenessService.observe("nus ta ma1101r    ").get();
+
+        ContextUpdateEvent bothTrailingSpaces =
+               (ContextUpdateEvent) awarenessService.observe("   nus ta ma1101r    ").get();
+
+        assertEquals(exactMatch.message, expected.message);
+        assertEquals(leftTrailingSpaces.message, expected.message);
+        assertEquals(rightTrailingSpaces.message, expected.message);
+        assertEquals(bothTrailingSpaces.message, expected.message);
+
     }
 
 }

--- a/src/test/java/seedu/address/model/awareness/AwarenessTest.java
+++ b/src/test/java/seedu/address/model/awareness/AwarenessTest.java
@@ -1,7 +1,4 @@
-package seedu.address.model;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+package seedu.address.model.awareness;
 
 import java.util.TreeMap;
 
@@ -13,6 +10,8 @@ import seedu.address.model.awareness.Awareness;
 import seedu.address.model.awareness.Dictionary;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.util.SampleDataUtil;
+
+import static org.junit.Assert.*;
 
 public class AwarenessTest {
 
@@ -27,6 +26,39 @@ public class AwarenessTest {
         TreeMap<String, ResumeEntry> nameToEntryMappings = null;
 
         new Awareness(dictionary, nameToEntryMappings);
+    }
+
+    @Test
+    public void getContextualResumeEntry_positiveCases() {
+
+        Awareness awareness = SampleDataUtil.getSampleAwareness();
+
+        // correct event name, where event name consists of a few full phrases --> match
+        String multipleFullPhrases = "teaching assistant ma1101r";
+        assertEquals(awareness.getContextualResumeEntry(multipleFullPhrases).get(), SampleDataUtil.MA1101R_TA);
+
+        // correct event name, where event name is a single full phrase --> match
+        String singleFullPhrase = "cs2103t";
+        assertEquals(awareness.getContextualResumeEntry(singleFullPhrase).get(), SampleDataUtil.NUS_CS2103T);
+
+    }
+
+    @Test
+    public void getContextualResumeEntry_negativeCases() {
+
+        Awareness awareness = SampleDataUtil.getSampleAwareness();
+
+        // incorrect event names --> no match
+        String incorrectEventName = "teching assistant ma1101r";
+        assertFalse(awareness.getContextualResumeEntry(incorrectEventName).isPresent());
+
+        // incomplete event name --> no match
+        String incompleteEventName = "cs2103";
+        assertFalse(awareness.getContextualResumeEntry(incompleteEventName).isPresent());
+
+        // event name given in wrong case --> no match
+        String wrongCaseEventName = "CS2103T";
+        assertFalse(awareness.getContextualResumeEntry(wrongCaseEventName).isPresent());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/awareness/AwarenessTest.java
+++ b/src/test/java/seedu/address/model/awareness/AwarenessTest.java
@@ -1,17 +1,17 @@
 package seedu.address.model.awareness;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
 import java.util.TreeMap;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.model.awareness.Awareness;
-import seedu.address.model.awareness.Dictionary;
 import seedu.address.model.entry.ResumeEntry;
 import seedu.address.model.util.SampleDataUtil;
-
-import static org.junit.Assert.*;
 
 public class AwarenessTest {
 


### PR DESCRIPTION
This PR fixes a fatal bug (cause program crash) that occurs when the awareness parser takes in empty strings. 

To fix, I've used the regex from AddressBookParser to filter out such invalid cases.
There is a bit of code duplication in AwarenessService and AddressBookParser